### PR TITLE
Remove logging restriction from tyr-cli

### DIFF
--- a/tyr-cli/src/main/resources/application.properties
+++ b/tyr-cli/src/main/resources/application.properties
@@ -1,3 +1,2 @@
 quarkus.native.additional-build-args = -H:ReflectionConfigurationFiles=reflection-config.json
 quarkus.banner.enabled=false
-quarkus.log.category."io.quarkus".level=ERROR


### PR DESCRIPTION
The GH action tyr-action will parse the output and the logging can be valuable in case of errors. 